### PR TITLE
Support avatars on webfinger results.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,20 @@ enum Link {
   /// ```
   #[serde(rename = "http://ostatus.org/schema/1.0/subscribe")]
   Subscribe,
+  /// This represents an avatar section for the actor.
+  ///
+  /// The actual structure here is closer to this:
+  ///
+  /// ```
+  ///  Avatar {
+  ///    href: String,
+  ///    #[serde(rename = "type")]
+  ///    media_type: String,
+  ///  }
+  /// ```
+  ///
+  #[serde(rename = "http://webfinger.net/rel/avatar")]
+  Avatar,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Avatars (or any unknown content in a webfinger response's link payload) could crash the client when they appeared in webfinger responses. This commit adds a unit struct that tolerates them, and some notes on what fields are included in case it ever makes sense to expand support.